### PR TITLE
Traefik now uses host networking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,15 @@
 version: "3.7"
 services:
   traefik:
-    image: traefik:latest
+    image: traefik:v2.1.6
     container_name: traefik
     restart: always
+    extra_hosts: 
+      - "host.docker.internal:192.168.32.1"
     command:
       - --api.insecure=true
       - --providers.docker=true
-      - --providers.docker.network=traefik_proxy
+      - --providers.docker.network=bridge
       - --providers.file.directory=/etc/traefik
       - --providers.file.filename=config.toml
       - --providers.docker.exposedbydefault=false
@@ -29,8 +31,6 @@ services:
     environment:
       - CF_API_EMAIL=${CF_EMAIL}
       - CF_API_KEY=${CF_API_KEY}
-    networks:
-      traefik_proxy:
     volumes:
       - ${HOME}/Docker/traefik/.letsencrypt:/letsencrypt
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -38,8 +38,6 @@ services:
   nginx-personal:
     image: linuxserver/nginx
     container_name: my-web-nginx
-    networks:
-      traefik_proxy:
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -53,7 +51,7 @@ services:
       - traefik.http.routers.myweb.entrypoints=websecure
       - traefik.http.routers.myweb.tls.certresolver=mydnschallenge
       - traefik.http.services.myweb.loadbalancer.server.port=80
-      - traefik.docker.network=traefik_proxy
+      - traefik.docker.network=bridge
   bitwarden:
     image: bitwardenrs/server
     restart: unless-stopped
@@ -66,11 +64,9 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-    networks:
-      traefik_proxy:
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_proxy
+      - traefik.docker.network=bridge
       - traefik.http.middlewares.redirect-https.redirectScheme.scheme=https
       - traefik.http.middlewares.redirect-https.redirectScheme.permanent=true
       - traefik.http.routers.bitwarden-ui-https.rule=${BWDOMAIN}
@@ -110,7 +106,6 @@ services:
     networks:
       macvlan101:
       macvlan100:
-      traefik_proxy:
     volumes:
       - ${HOME}/Docker/homeassistant:/config
     environment:
@@ -127,12 +122,10 @@ services:
       - traefik.http.routers.homeassistant.entrypoints=websecure
       - traefik.http.routers.homeassistant.tls.certresolver=mydnschallenge
       - traefik.http.services.homeassistant.loadbalancer.server.port=8123
-      - traefik.docker.network=traefik_proxy
+      - traefik.docker.network=bridge
   nodered:
     container_name: node-red
     restart: unless-stopped
-    networks:
-      traefik_proxy:
     image: nodered/node-red:latest
     depends_on:
       - "homeassistant"
@@ -148,7 +141,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.nodered.rule=Host(`node-red.hill`)
       - traefik.http.routers.nodered.entrypoints=web
-      - traefik.docker.network=traefik_proxy
+      - traefik.docker.network=bridge
   filebrowser:
     image: halverneus/static-file-server
     container_name: fileserver-web
@@ -159,20 +152,16 @@ services:
     restart: unless-stopped
     volumes:
       - /mnt/zfs/Docker/fileserve:/web
-    networks:
-      traefik_proxy:
     labels:
       - traefik.enable=true
       - traefik.http.routers.fileserve.rule=${FS_NOHAT}
       - traefik.http.routers.fileserve.entrypoints=websecure
       - traefik.http.routers.fileserve.tls.certresolver=mydnschallenge
       - traefik.http.services.fileserve.loadbalancer.server.port=8080
-      - traefik.docker.network=traefik_proxy
+      - traefik.docker.network=bridge
   thecap:
     image: linuxserver/nginx
     container_name: cap-web-nginx
-    networks:
-      traefik_proxy:
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -186,7 +175,7 @@ services:
       - traefik.http.routers.cap.entrypoints=websecure
       - traefik.http.routers.cap.tls.certresolver=mydnschallenge
       - traefik.http.services.cap.loadbalancer.server.port=80
-      - traefik.docker.network=traefik_proxy
+      - traefik.docker.network=bridge
   samba:
     image: dperson/samba
     container_name: samba
@@ -222,14 +211,33 @@ services:
       - traefik.http.routers.njco.entrypoints=websecure
       - traefik.http.routers.njco.tls.certresolver=mydnschallenge    
       - traefik.http.services.njco.loadbalancer.server.port=80
-      - traefik.docker.network=traefik_proxy
-    networks:
-      traefik_proxy:
+      - traefik.docker.network=bridge
+  plex:
+    image: linuxserver/plex
+    container_name: plex-pms
+    network_mode: host
+    environment:
+      - PUID${PUID}
+      - PGID=${PGID}
+      - VERSION=latest
+      - UMASK_SET=022
+    volumes:
+      - ${HOME}/Docker/plex/library:/config
+      - /mnt/zfs/Storage/Media/TV:/tv
+      - /mnt/zfs/Storage/Media/Movies:/movies
+      - /mnt/zfs/Storage/Media/Music:/music
+    restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=bridge
+      - traefik.http.routers.plex.rule=${PLEXHOST}
+      - traefik.http.routers.plex.entrypoints=websecure
+      - traefik.http.routers.plex.tls.certresolver=mydnschallenge
+      - traefik.http.services.plex.loadbalancer.server.port=32400
+      - traefik.http.routers.plex.rule=Host(`plex.hill`)
+      - traefik.http.routers.plex.entrypoints=web
 
 networks:
-  traefik_proxy:
-    external:
-      name: traefik_proxy
   macvlan101:
     external: true
   macvlan100:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,14 @@
 version: "3.7"
 services:
   traefik:
-    image: traefik:v2.1.6
+    image: containous/traefik:experimental-master
     container_name: traefik
     restart: always
     extra_hosts: 
-      - "host.docker.internal:172.17.0.1"
+      - host.docker.internal:172.17.0.1
     command:
       - --api.insecure=true
       - --providers.docker=true
-      - --providers.docker.network=bridge
       - --providers.file.directory=/etc/traefik
       - --providers.file.filename=config.toml
       - --providers.docker.exposedbydefault=false
@@ -37,7 +36,9 @@ services:
       - ${HOME}/Docker/traefik:/etc/traefik
   nginx-personal:
     image: linuxserver/nginx
-    container_name: my-web-nginx    
+    container_name: my-web-nginx
+    depends_on: 
+      - traefik    
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -55,6 +56,8 @@ services:
     image: bitwardenrs/server
     restart: unless-stopped
     container_name: bitwarden-rs
+    depends_on: 
+      - traefik
     volumes:
       - ${HOME}/Docker/bitwarden:/data
     environment:
@@ -125,7 +128,8 @@ services:
     restart: unless-stopped
     image: nodered/node-red:latest
     depends_on:
-      - "homeassistant"
+      - homeassistant
+      - traefik
     user: root
     environment:
       - TZ=${TZ}
@@ -141,6 +145,8 @@ services:
   filebrowser:
     image: halverneus/static-file-server
     container_name: fileserver-web
+    depends_on: 
+      - traefik
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -157,6 +163,8 @@ services:
   thecap:
     image: linuxserver/nginx
     container_name: cap-web-nginx
+    depends_on: 
+      - traefik
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -192,6 +200,8 @@ services:
   nginx:
     image: linuxserver/nginx
     container_name: njco-web-nginx
+    depends_on: 
+      - traefik
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -208,6 +218,8 @@ services:
   plex:
     image: linuxserver/plex
     container_name: plex-pms
+    tmpfs:
+      - /tmp
     network_mode: host
     environment:
       - PUID${PUID}
@@ -226,8 +238,8 @@ services:
       - traefik.http.routers.plex.entrypoints=websecure
       - traefik.http.routers.plex.tls.certresolver=mydnschallenge
       - traefik.http.services.plex.loadbalancer.server.port=32400
-      - traefik.http.routers.plex.rule=Host(`plex.hill`)
-      - traefik.http.routers.plex.entrypoints=web
+      - traefik.http.routers.plex-internal.rule=Host(`plex.hill`)
+      - traefik.http.routers.plex-internal.entrypoints=web
 
 networks:
   macvlan101:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: traefik
     restart: always
     extra_hosts: 
-      - "host.docker.internal:192.168.32.1"
+      - "host.docker.internal:172.17.0.1"
     command:
       - --api.insecure=true
       - --providers.docker=true
@@ -37,7 +37,7 @@ services:
       - ${HOME}/Docker/traefik:/etc/traefik
   nginx-personal:
     image: linuxserver/nginx
-    container_name: my-web-nginx
+    container_name: my-web-nginx    
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -51,7 +51,6 @@ services:
       - traefik.http.routers.myweb.entrypoints=websecure
       - traefik.http.routers.myweb.tls.certresolver=mydnschallenge
       - traefik.http.services.myweb.loadbalancer.server.port=80
-      - traefik.docker.network=bridge
   bitwarden:
     image: bitwardenrs/server
     restart: unless-stopped
@@ -63,10 +62,9 @@ services:
       - SIGNUPS_ALLOWED= false
       - PUID=${PUID}
       - PGID=${PGID}
-      - TZ=${TZ}
+      - TZ=${TZ}      
     labels:
       - traefik.enable=true
-      - traefik.docker.network=bridge
       - traefik.http.middlewares.redirect-https.redirectScheme.scheme=https
       - traefik.http.middlewares.redirect-https.redirectScheme.permanent=true
       - traefik.http.routers.bitwarden-ui-https.rule=${BWDOMAIN}
@@ -90,7 +88,7 @@ services:
   cloudflare-ddns:
     image: oznu/cloudflare-ddns:latest
     container_name: cloudflare-dynDNS
-    restart: always
+    restart: always  
     environment:
       - EMAIL=${CF_EMAIL}
       - API_KEY=${CF_API_KEY}
@@ -122,7 +120,6 @@ services:
       - traefik.http.routers.homeassistant.entrypoints=websecure
       - traefik.http.routers.homeassistant.tls.certresolver=mydnschallenge
       - traefik.http.services.homeassistant.loadbalancer.server.port=8123
-      - traefik.docker.network=bridge
   nodered:
     container_name: node-red
     restart: unless-stopped
@@ -141,7 +138,6 @@ services:
       - traefik.enable=true
       - traefik.http.routers.nodered.rule=Host(`node-red.hill`)
       - traefik.http.routers.nodered.entrypoints=web
-      - traefik.docker.network=bridge
   filebrowser:
     image: halverneus/static-file-server
     container_name: fileserver-web
@@ -158,7 +154,6 @@ services:
       - traefik.http.routers.fileserve.entrypoints=websecure
       - traefik.http.routers.fileserve.tls.certresolver=mydnschallenge
       - traefik.http.services.fileserve.loadbalancer.server.port=8080
-      - traefik.docker.network=bridge
   thecap:
     image: linuxserver/nginx
     container_name: cap-web-nginx
@@ -175,7 +170,6 @@ services:
       - traefik.http.routers.cap.entrypoints=websecure
       - traefik.http.routers.cap.tls.certresolver=mydnschallenge
       - traefik.http.services.cap.loadbalancer.server.port=80
-      - traefik.docker.network=bridge
   samba:
     image: dperson/samba
     container_name: samba
@@ -211,7 +205,6 @@ services:
       - traefik.http.routers.njco.entrypoints=websecure
       - traefik.http.routers.njco.tls.certresolver=mydnschallenge    
       - traefik.http.services.njco.loadbalancer.server.port=80
-      - traefik.docker.network=bridge
   plex:
     image: linuxserver/plex
     container_name: plex-pms
@@ -229,7 +222,6 @@ services:
     restart: unless-stopped
     labels:
       - traefik.enable=true
-      - traefik.docker.network=bridge
       - traefik.http.routers.plex.rule=${PLEXHOST}
       - traefik.http.routers.plex.entrypoints=websecure
       - traefik.http.routers.plex.tls.certresolver=mydnschallenge

--- a/traefik_proxy_command.txt
+++ b/traefik_proxy_command.txt
@@ -1,0 +1,10 @@
+docker network create \
+  --driver=bridge \
+  --subnet=172.18.0.0/16 \
+  --ip-range=172.18.0.0/24 \
+  --gateway=172.18.0.1 \
+  --opt com.docker.network.bridge.host_binding_ipv4=0.0.0.0 \
+  --opt com.docker.network.driver.mtu=1500 \
+  --opt com.docker.network.bridge.enable_ip_masquerade=true \
+  --opt com.docker.network.bridge.enable_icc=true \
+  traefik_proxy


### PR DESCRIPTION
For better support with in home services such as home-assistant and Plex traefik now uses host networking for reverse proxying. 

Currently this is not pushed to official docker releases. Using experimental and need to move ha to host networking. 

Relates to: https://github.com/anthr76/docker-compose-hill/issues/1
